### PR TITLE
Added support for Kotlin markdown

### DIFF
--- a/DiscordBeam/Base/src/main/java/de/lukweb/discordbeam/FileExtensionMarkdownLanguage.java
+++ b/DiscordBeam/Base/src/main/java/de/lukweb/discordbeam/FileExtensionMarkdownLanguage.java
@@ -1,0 +1,27 @@
+package de.lukweb.discordbeam;
+
+public enum FileExtensionMarkdownLanguage {
+	KOTLIN("kt", "kotlin");
+
+	private final String extension;
+	private final String language;
+
+	FileExtensionMarkdownLanguage(String extension, String language) {
+		this.extension = extension;
+		this.language = language;
+	}
+
+	public static FileExtensionMarkdownLanguage getByExtension(String extension) {
+		for (FileExtensionMarkdownLanguage fileExtensionMarkdownLanguage : FileExtensionMarkdownLanguage.values()) {
+			if (fileExtensionMarkdownLanguage.extension.equals(extension)) {
+				return fileExtensionMarkdownLanguage;
+			}
+		}
+
+		return null;
+	}
+
+	public String getLanguage() {
+		return language;
+	}
+}

--- a/DiscordBeam/Base/src/main/java/de/lukweb/discordbeam/FileExtensionMarkdownLanguage.java
+++ b/DiscordBeam/Base/src/main/java/de/lukweb/discordbeam/FileExtensionMarkdownLanguage.java
@@ -21,6 +21,10 @@ public enum FileExtensionMarkdownLanguage {
 		return null;
 	}
 
+	public String getExtension() {
+		return extension;
+	}
+
 	public String getLanguage() {
 		return language;
 	}

--- a/DiscordBeam/Base/src/main/java/de/lukweb/discordbeam/uploaders/DiscordUploader.java
+++ b/DiscordBeam/Base/src/main/java/de/lukweb/discordbeam/uploaders/DiscordUploader.java
@@ -3,6 +3,7 @@ package de.lukweb.discordbeam.uploaders;
 import com.intellij.openapi.components.ServiceManager;
 import de.lukweb.discordbeam.DiscordSettings;
 import de.lukweb.share.ShareResult;
+import de.lukweb.discordbeam.FileExtensionMarkdownLanguage;
 import okhttp3.*;
 
 import java.io.IOException;
@@ -32,7 +33,11 @@ public class DiscordUploader {
     }
 
     public void uploadCode(String text, String extension, ShareResult result) {
-        uploadText("```" + extension + "\n" + text + "\n```", result);
+        String markdownLanguage = extension;
+        FileExtensionMarkdownLanguage language = FileExtensionMarkdownLanguage.getByExtension(extension);
+        if (language != null) markdownLanguage =  language.getLanguage();
+
+        uploadText("```" + markdownLanguage + "\n" + text + "\n```", result);
     }
 
     public void uploadFile(byte[] content, String fileName, ShareResult result) {


### PR DESCRIPTION
Added support for Kotlin as markdown language, and possibly other languages that don't use their extension as markdown language. In this case, the extension (kt) does not work in markdown because it should be "kotlin".

This could, later on, be extended to add even more languages if necessary. 